### PR TITLE
NMP

### DIFF
--- a/src/board.hpp
+++ b/src/board.hpp
@@ -164,6 +164,18 @@ struct Board {
     zobrist ^= stm_rand;
   }
 
+  constexpr void make_null_move() {
+    if (ep_square != Squares::NONE)
+      zobrist ^= ep_rands[ep_square.file()];
+
+    ep_square = Squares::NONE;
+
+    stm = ~stm;
+    zobrist ^= stm_rand;
+
+    halfmove_clock = 0;
+  }
+
   // Does not account for pins
   constexpr Bitboard threats(Side side) const {
     Bitboard threats;

--- a/src/searcher.hpp
+++ b/src/searcher.hpp
@@ -161,11 +161,26 @@ class Searcher {
            (node->type == TTNode::Type::LOWERBOUND && node->value >= beta)))
         return node->value;
 
-      if (!board.is_check())
+      const bool is_check = board.is_check();
+
+      if (!is_check)
         if (int static_eval = Eval::eval(board);
             static_eval < CHECKMATE_THRESHOLD &&
             static_eval >= beta + depth * 100)
           return static_eval;
+
+      if (!is_check || (board.side_occupancy[board.stm] !=
+                        (board.pieces[board.stm][Pieces::PAWN] |
+                         board.pieces[board.stm][Pieces::KING]))) {
+        Board copy = board;
+        copy.make_null_move();
+
+        int nmp_value = -negamax<false>(copy, std::max(depth - 3, 0), ply + 1,
+                                        -beta, -(beta - 1));
+
+        if (nmp_value >= beta)
+          return nmp_value;
+      }
     }
 
     Move best_move{};


### PR DESCRIPTION
Results of dev vs main (8+0.08, NULL, NULL, UHO_Lichess_4852_v1.epd):
Elo: 126.37 +/- 34.88, nElo: 166.34 +/- 41.91
LOS: 100.00 %, DrawRatio: 31.82 %, PairsRatio: 4.62
Games: 264, Wins: 148, Losses: 56, Draws: 60, Points: 178.0 (67.42 %)
Ptnml(0-2): [2, 14, 42, 38, 36], WL/DD Ratio: 9.50
LLR: 2.91 (-2.25, 2.89) [0.00, 10.00]